### PR TITLE
changed water.gdshader.ssr_resolution minimum editor slider range fro…

### DIFF
--- a/shaders/water.gdshader
+++ b/shaders/water.gdshader
@@ -14,7 +14,7 @@ uniform float surface_texture_roughness : hint_range(0.0, 1.0, 0.01) = 0.6;
 uniform float surface_texture_scale : hint_range(0.001, 2.0, 0.001) = 0.3;
 uniform float surface_texture_time_scale : hint_range(0.001, 2.0, 0.001) = 0.06;
 
-uniform float ssr_resolution   : hint_range(0.0, 10.0, 0.1)		= 2.0;
+uniform float ssr_resolution   : hint_range(0.01, 10.0, 0.1)	= 2.0;
 uniform float ssr_max_travel   : hint_range(0.0, 200.0, 0.1) 	= 30.0;
 uniform float ssr_max_diff     : hint_range(0.1, 10.0, 0.1) 	= 4.0;
 uniform float ssr_mix_strength : hint_range(0.0, 1.0, 0.01) 	= 0.7;


### PR DESCRIPTION
setting water.gdshader.ssr_resolution to 0.0 in editor, while in playmode (via remote) was crashing my video driver. changing it to 0.01 tanks my fps (0.1 == 60fps, 0.01 == 7 fps) but doesn't crash my video card.

0.01 is probably a safer minimum for the majority of systems.